### PR TITLE
Sort kafdrop headers and topic names

### DIFF
--- a/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/ViewProducerController.java
+++ b/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/ViewProducerController.java
@@ -13,6 +13,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeSet;
 import javax.swing.JOptionPane;
 import javax.swing.table.DefaultTableModel;
 
@@ -47,7 +48,7 @@ public class ViewProducerController extends ViewProducer {
     }
 
     private void initializeTopics() {
-        final var topics = listTopicUseCase.execute();
+        final var topics = new TreeSet<>(listTopicUseCase.execute());
         topics.forEach(kafkaTopicDto -> comboTopic.addItem(kafkaTopicDto.getId().getValue()));
         comboTopic.setSelectedItem(topicName);
     }

--- a/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/ViewProducerController.java
+++ b/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/ViewProducerController.java
@@ -49,7 +49,9 @@ public class ViewProducerController extends ViewProducer {
 
     private void initializeTopics() {
         final var topics = new TreeSet<>(listTopicUseCase.execute());
-        topics.forEach(kafkaTopicDto -> comboTopic.addItem(kafkaTopicDto.getId().getValue()));
+        for (final var kafkaTopicDto : topics) {
+            comboTopic.addItem(kafkaTopicDto.getId().getValue());
+        }
         comboTopic.setSelectedItem(topicName);
     }
 
@@ -143,7 +145,9 @@ public class ViewProducerController extends ViewProducer {
 
     private void populateTableWithHeaders(Map<String, String> headerMap) {
         createTable();
-        headerMap.forEach((key, value) -> model.addRow(new Object[]{key, value}));
+        for (final var entry : headerMap.entrySet()) {
+            model.addRow(new Object[]{entry.getKey(), entry.getValue()});
+        }
     }
 
     private void showMessageDialog(String message) {

--- a/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/ViewProducerController.java
+++ b/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/ViewProducerController.java
@@ -62,7 +62,7 @@ public class ViewProducerController extends ViewProducer {
         btnSave.addActionListener(e -> save());
         btnPlus.addActionListener(e -> plus());
         btnSubtract.addActionListener(e -> subtract());
-        btnImportHeaderKafdrop.addActionListener(e -> importHeaderKafrop());
+        btnImportHeaderKafdrop.addActionListener(e -> importHeadersFromKafdrop());
         btnFormatter.addActionListener(e -> txtValue.setText(JsonUtil.format(txtValue.getText())));
     }
 
@@ -134,8 +134,8 @@ public class ViewProducerController extends ViewProducer {
             txtValue.getText().strip(), map);
     }
 
-    private void importHeaderKafrop() {
-        final var header = JOptionUtil.showCustomInputDialog("Copy the header from Kafdrop:",
+    private void importHeadersFromKafdrop() {
+        final var header = JOptionUtil.showCustomInputDialog("Copy headers from Kafdrop:",
             "Complete");
         if (header == null || header.isBlank()) {
             return;

--- a/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/util/HeaderParser.java
+++ b/infrastructure/src/main/java/br/com/kafkamanager/infrastructure/swing/util/HeaderParser.java
@@ -1,14 +1,14 @@
 package br.com.kafkamanager.infrastructure.swing.util;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class HeaderParser {
 
     public static Map<String, String> parseEventString(String eventString) {
-        final var eventMap = new HashMap<String, String>();
+        final var eventMap = new TreeMap<String, String>();
         final var keyValuePairs = eventString.split(", ");
         for (String pair : keyValuePairs) {
             final var entry = pair.split(": ");


### PR DESCRIPTION
- Use implementations of `TreeMap` and `TreeSet` to automatically sort headers when importing from Kafdrop and when listing kafka topic names.
- Replace `foreach` loops with enhanced `for` when producing side-effects.
- Rename method in `ViewProducerController`.